### PR TITLE
Add sync throw task test

### DIFF
--- a/packages/netron/test/fixtures/tasks.ts
+++ b/packages/netron/test/fixtures/tasks.ts
@@ -13,3 +13,7 @@ export function syncTask(a: number, b: number) {
 export async function delayedTask(ms: number) {
   return new Promise((resolve) => setTimeout(() => resolve('done'), ms));
 }
+
+export function throwingTask() {
+  throw new Error('Intentional sync failure');
+}

--- a/packages/netron/test/fixtures/tasks/t5.js
+++ b/packages/netron/test/fixtures/tasks/t5.js
@@ -1,0 +1,7 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.throwingTask = throwingTask;
+function throwingTask() {
+  throw new Error('Intentional sync failure');
+}

--- a/packages/netron/test/task-manager.spec.ts
+++ b/packages/netron/test/task-manager.spec.ts
@@ -1,7 +1,13 @@
 import path from 'path';
 
 import { TaskManager } from '../dist';
-import { syncTask, asyncTask, failingTask, delayedTask } from './fixtures/tasks';
+import {
+  syncTask,
+  asyncTask,
+  failingTask,
+  delayedTask,
+  throwingTask,
+} from './fixtures/tasks';
 
 describe('TaskManager', () => {
   let manager: TaskManager;
@@ -26,6 +32,11 @@ describe('TaskManager', () => {
   it('handling error in a task', async () => {
     manager.addTask(failingTask);
     await expect(manager.runTask('failingTask')).rejects.toThrow('Intentional task failure');
+  });
+
+  it('synchronous task throwing error', async () => {
+    manager.addTask(throwingTask);
+    await expect(manager.runTask('throwingTask')).rejects.toThrow('Intentional sync failure');
   });
 
   // ✅ Test timeout


### PR DESCRIPTION
## Summary
- add new `throwingTask` fixture
- include compiled JS fixture `t5.js`
- test sync throw path in `TaskManager`

## Testing
- `yarn workspace @devgrid/netron test` *(fails: fetch failed - offline)*